### PR TITLE
Consider removing core_kernel dependency

### DIFF
--- a/META.ab
+++ b/META.ab
@@ -1,6 +1,6 @@
 version = "$(pkg_version)"
 description = "OCaml bindings for the virtual-dom library"
-requires = "core_kernel js_of_ocaml tyxml"
+requires = "js_of_ocaml tyxml"
 archive(byte  ) = "virtual_dom.cma"
 archive(native) = "virtual_dom.cmxa"
 plugin(byte  ) = "virtual_dom.cma"

--- a/_oasis
+++ b/_oasis
@@ -32,6 +32,5 @@ Library virtual_dom
                 Std,
                 Tyxml,
                 Vdom
-  BuildDepends: core_kernel,
-                js_of_ocaml,
+  BuildDepends: js_of_ocaml,
                 tyxml

--- a/example/terminal/terminal.ml
+++ b/example/terminal/terminal.ml
@@ -1,6 +1,5 @@
 open Js_of_ocaml
 open Virtual_dom.Std
-open Core_kernel.Std
 open Vdom
 
 let colors =

--- a/opam
+++ b/opam
@@ -13,9 +13,8 @@ depends: [
   "ocamlbuild"     {build}
   "oasis"          {build & >= "0.4"}
   "ocamlfind"      {build & >= "1.3.2"}
-  "core_kernel"
   "js-build-tools" {build}
-  "js_of_ocaml"
+  "js_of_ocaml"    {>= "2.8.1"}
   "ppx_driver"
   "tyxml"
 ]

--- a/src/attr.ml
+++ b/src/attr.ml
@@ -1,4 +1,3 @@
-open Core_kernel.Std
 open Js_of_ocaml
 
 type t =
@@ -9,7 +8,7 @@ let create name value = Attribute (name, Js.Unsafe.inject (Js.string value))
 let property  name value = Property (name, value)
 
 let class_ c = create "class" c
-let classes classes = class_ (String.concat classes ~sep:" ")
+let classes classes = class_ (String.concat " " classes)
 
 let id s = create "id" s
 
@@ -22,7 +21,7 @@ let on event handler : t =
 
 let style props =
   let obj = Js.Unsafe.obj [||] in
-  List.iter ~f:(fun (k, v) ->
+  List.iter (fun (k, v) ->
     Js.Unsafe.set obj (Js.string k) (Js.string v))
     props;
   Property ("style", obj)
@@ -59,7 +58,7 @@ let on_input  = on_input_event "input"
 
 let list_to_obj attrs =
   let attrs_obj = Js.Unsafe.obj [||] in
-  List.iter ~f:(function
+  List.iter (function
     | Property (name, value) ->
       Js.Unsafe.set attrs_obj
         (Js.string name)

--- a/src/node.mli
+++ b/src/node.mli
@@ -1,5 +1,4 @@
 open Js_of_ocaml
-open Core_kernel.Std
 
 type t
 type node_creator = ?key:string -> Attr.t list -> t list -> t
@@ -41,13 +40,15 @@ val svg
 
 val to_dom : t -> Dom_html.element Js.t
 
+type object_id = int (* TODO *)
+
 (* If you want a widget to be diffed against another (by calling the update
    function of the new widget), the two widgets must have physically equal
    ids. *)
 val widget
   :  ?destroy:('s -> (#Dom_html.element as 'e) Js.t -> unit)
   -> ?update:('s -> 'e Js.t -> 's * 'e Js.t)
-  -> id:('s * 'e Js.t) Type_equal.Id.t
+  -> id:object_id
   -> init:(unit -> 's * 'e Js.t)
   -> unit
   -> t


### PR DESCRIPTION
This code shouldn't be merged as-is, but it might be a start.

I'm interested in using vdom, but don't particularly want to take on the core_kernel dependency. It only seems to provide one feature here which isn't in the stdlib, which is `Type_equal`.

It won't matter if you're already using core (as you surely are for your actual apps), but for someone who would just like to use this library it's a heavy dependency. Both in terms of code size / compilation and complexity:

### without core:
hello_vdom.byte: 433kb
hello_vdom.js: 132kb

### with core:
hello_vdom.byte: 3.6mb (and it shows in compilation time)
hello_vdom.js: 1.2mb

As for complexity, I couldn't actually get the core version to run in the browser due to a missing implementation for some `bin_prot` stubs.

I've replaced `Type_equal` with a dumb integer (which I had to jump through some hoops to get into JS, as this was a quick hack), but I'm assuming you have better ideas on how to do this properly if you're interested in removing the core dependency. If you're not interested then that's fine, in which case I might try and maintain this branch for my own use, but would still appreciate any advice you have on what `Type_equal` would best be replaced with.